### PR TITLE
Fix for fpermissive warnings on shifting negative numbers.

### DIFF
--- a/include/fi/private/Limits.hpp
+++ b/include/fi/private/Limits.hpp
@@ -49,7 +49,7 @@ namespace Fi {
 	};
 
 	template<typename T, std::size_t W> struct MinVal<T, W, SIGNED> {
-		static const T value = (T(1) << (W-1)) | (T(-1) << (W-1));
+		static const T value = ~((1u << (W-1)) - 1);
 	};
 
 

--- a/include/fi/private/Masks.hpp
+++ b/include/fi/private/Masks.hpp
@@ -39,7 +39,7 @@ namespace Fi {
 	 */
 	template<typename T, std::size_t W>
 	struct TMask {
-		static const T value = ~( (~T(0)) << W );
+		static const T value = (1u << W) - 1;
 	};
 
 
@@ -56,7 +56,7 @@ namespace Fi {
 
 	template<typename T, std::size_t W>
 	struct SMask<T, W, SIGNED> {
-		static const T value = (~T(0)) << (W-1);
+		static const T value = ~((1u << (W - 1)) - 1);
 	};
 
 	template<typename T, std::size_t W>
@@ -74,7 +74,7 @@ namespace Fi {
 	 */
 	template<typename T, std::size_t W, std::size_t F>
 	struct FMask {
-		static const T value = (F == 8*sizeof(T)) ? ~T(0) : ~(~T(0) << F);
+		static const T value = (F == 8*sizeof(T)) ? ~T(0) : ((1u << F) - 1);
 	};
 
 }


### PR DESCRIPTION
With newer versions of gcc fpermissive warning/error appears for shifting negative numbers. This pull request trades shifts for equivalent logic to get binary masks.